### PR TITLE
Add Allocation table for Vector Region

### DIFF
--- a/organisational-boundaries/Vector Region/AllocationTable.csv
+++ b/organisational-boundaries/Vector Region/AllocationTable.csv
@@ -1,0 +1,6 @@
+OBJECTID,REGION_NAME
+"1","Eastern"
+"2","North West & Central"
+"3","Scotland"
+"4","Southern"
+"5","Wales and Western"

--- a/organisational-boundaries/Vector Region/AllocationTable.csv
+++ b/organisational-boundaries/Vector Region/AllocationTable.csv
@@ -3,4 +3,4 @@ OBJECTID,REGION_NAME
 "2","North West & Central"
 "3","Scotland"
 "4","Southern"
-"5","Wales and Western"
+"5","Wales & Western"


### PR DESCRIPTION
The allocation table for Vector Regions was empty this adds it in, the other CSVs could then reference this if needed in the future rather than relying on the strings to be match in the other allocation tables.